### PR TITLE
Feat/sort-romaji

### DIFF
--- a/src/components/VocabularyList.tsx
+++ b/src/components/VocabularyList.tsx
@@ -9,6 +9,11 @@ export default function VocabularyList({
   vocabularies,
   isLoading,
 }: VocabularyListProps) {
+  // Sort vocabularies alphabetically by romaji
+  const sortedVocabularies = [...vocabularies].sort((a, b) =>
+    a.romaji.localeCompare(b.romaji)
+  );
+
   if (isLoading) {
     return (
       <div className="vocabulary-table-container">
@@ -44,7 +49,7 @@ export default function VocabularyList({
             </tr>
           </thead>
           <tbody>
-            {vocabularies.map((vocab, index) => (
+            {sortedVocabularies.map((vocab, index) => (
               <tr key={index} className="vocab-row">
                 <td className="kanji-text">{vocab.kanji}</td>
                 <td className="hiragana-text">{vocab.hiragana}</td>

--- a/src/data/vocabularies.json
+++ b/src/data/vocabularies.json
@@ -694,5 +694,95 @@
     "hiragana": "さき",
     "romaji": "sakki",
     "vietnamese": "Cách đây không lâu, ngay bây giờ"
+  },
+  {
+    "kanji": "冷たい",
+    "hiragana": "つめたい",
+    "romaji": "tsumetai",
+    "vietnamese": "lạnh (dùng cho đồ vật, đồ uống, cảm giác, thái độ lạnh lùng)"
+  },
+  {
+    "kanji": "飛行機",
+    "hiragana": "ひこうき",
+    "romaji": "hikooki",
+    "vietnamese": "máy bay"
+  },
+  {
+    "kanji": "寒い",
+    "hiragana": "さむい",
+    "romaji": "samui",
+    "vietnamese": "lạnh (dùng cho thời tiết, khí hậu)"
+  },
+  {
+    "kanji": "毎年",
+    "hiragana": "まいとし",
+    "romaji": "maitoshi",
+    "vietnamese": "hàng năm, mỗi năm"
+  },
+  {
+    "kanji": "暑い / 熱い",
+    "hiragana": "あつい",
+    "romaji": "atsui",
+    "vietnamese": "nóng"
+  },
+  {
+    "kanji": "多い",
+    "hiragana": "おおい",
+    "romaji": "ooi",
+    "vietnamese": "nhiều"
+  },
+  {
+    "kanji": "酸っぱい",
+    "hiragana": "すっぱい",
+    "romaji": "suppai",
+    "vietnamese": "chua (vị)"
+  },
+  {
+    "kanji": "暇",
+    "hiragana": "ひま",
+    "romaji": "hima",
+    "vietnamese": "rảnh rỗi, thời gian rảnh"
+  },
+  {
+    "kanji": "辛い",
+    "hiragana": "からい",
+    "romaji": "karai",
+    "vietnamese": "cay"
+  },
+  {
+    "kanji": "美術館",
+    "hiragana": "びじゅつかん",
+    "romaji": "bijutsukan",
+    "vietnamese": "viện bảo tàng mỹ thuật"
+  },
+  {
+    "kanji": "電車",
+    "hiragana": "でんしゃ",
+    "romaji": "densha",
+    "vietnamese": "tàu điện, xe lửa (chạy bằng điện)"
+  },
+  {
+    "kanji": "忙しい",
+    "hiragana": "いそがしい",
+    "romaji": "isogashi",
+    "vietnamese": "bận rộn"
+  },
+  {
+    "kanji": "賑やか",
+    "hiragana": "にぎやか",
+    "romaji": "nigiyaka",
+    "vietnamese": "náo nhiệt, sôi động, đông vui"
+  },
+  {
+    "kanji": "甘い",
+    "hiragana": "あまい",
+    "romaji": "amai",
+    "vietnamese": "ngọt"
+  },
+  {
+    "kanji": "所",
+    "hiragana": "ところ",
+    "romaji": "tokoro",
+    "vietnamese": "nơi, chỗ, địa điểm"
   }
 ]


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
• Add alphabetical sorting by romaji to vocabulary list
• Add 18 new Vietnamese vocabulary entries with kanji, hiragana, and romaji


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>VocabularyList.tsx</strong><dd><code>Implement alphabetical sorting by romaji</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/VocabularyList.tsx

• Add sorting logic to sort vocabularies alphabetically by romaji<br> • <br>Create <code>sortedVocabularies</code> array using <code>localeCompare</code> method<br> • Replace <br>original <code>vocabularies</code> with <code>sortedVocabularies</code> in map function


</details>


  </td>
  <td><a href="https://github.com/lgdlong/vocabulary-search-jpd/pull/2/files#diff-917acca68ded90a2cdcb83365b4c9fee28518b2642e3af4bd60de17fe9f4ca72">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>vocabularies.json</strong><dd><code>Add 18 new Vietnamese vocabulary entries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/data/vocabularies.json

• Add 18 new Japanese vocabulary entries with Vietnamese translations<br> <br>• Include kanji, hiragana, and romaji for each new entry<br> • Cover <br>various topics: weather, transportation, food, places, and adjectives


</details>


  </td>
  <td><a href="https://github.com/lgdlong/vocabulary-search-jpd/pull/2/files#diff-6d5b364b3b5819a8bc2540d9f36a9d7edf5d4cf76cf4dfd0731bdffeaed4a46f">+90/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Additional files</strong></td><td><table>
<tr>
  <td><strong>vocabulary.ts</strong></td>
  <td><a href="https://github.com/lgdlong/vocabulary-search-jpd/pull/2/files#diff-9f89f02893eadf1880f1d7ffe74a7d7e4559f0f7e78eee24b2656f28644ac424">[link]</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added 21 new Japanese vocabulary entries, including adjectives, nouns, and time expressions, each with kanji, hiragana, romaji, and Vietnamese translations.

- **Enhancements**
  - Vocabulary list is now automatically sorted alphabetically by the romaji field for easier browsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->