### PR TITLE
feat: add new vocabulary entries with kanji, hiragana, romaji, and Vietnamese translations

### DIFF
--- a/src/data/vocabularies.json
+++ b/src/data/vocabularies.json
@@ -784,5 +784,23 @@
     "hiragana": "ところ",
     "romaji": "tokoro",
     "vietnamese": "nơi, chỗ, địa điểm"
+  },
+  {
+    "kanji": "見学します",
+    "hiragana": "けんがくします",
+    "romaji": "kengaku shimasu",
+    "vietnamese": "tham quan để học hỏi, đi thực tế"
+  },
+  {
+    "kanji": "美味しい",
+    "hiragana": "おいしい",
+    "romaji": "oishii",
+    "vietnamese": "ngon"
+  },
+  {
+    "kanji": "どうして",
+    "hiragana": "どうして",
+    "romaji": "doushite",
+    "vietnamese": "tại sao"
   }
 ]


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
• Added 3 new Japanese vocabulary entries to the vocabulary database
• Included complete translations with kanji, hiragana, romaji, and Vietnamese meanings


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vocabularies.json</strong><dd><code>Add three Japanese vocabulary entries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/data/vocabularies.json

• Added "見学します" (kengaku shimasu) - to visit for learning/field trip<br> • <br>Added "美味しい" (oishii) - delicious/tasty<br> • Added "どうして" (doushite) - <br>why/how come


</details>


  </td>
  <td><a href="https://github.com/lgdlong/vocabulary-search-jpd/pull/4/files#diff-6d5b364b3b5819a8bc2540d9f36a9d7edf5d4cf76cf4dfd0731bdffeaed4a46f">+18/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added three new vocabulary entries: "見学します" (to visit for learning), "美味しい" (delicious), and "どうして" (why).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->